### PR TITLE
 chore(ci): build with recent jruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ rvm:
   - 2.3.7
   - 2.4.4
   - 2.5.1
+  - jruby-9.1.17.0
+  - jruby-9.2.0.0
 
 script:
   - bundle exec rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,6 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    byebug (10.0.2)
     crass (1.0.4)
     diff-lcs (1.3)
     faraday (0.15.2)
@@ -44,7 +43,6 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.16)
-  byebug (~> 10.0)
   html2rss!
   rspec (~> 3.0)
   vcr (~> 4.0)

--- a/bin/console
+++ b/bin/console
@@ -2,7 +2,6 @@
 
 require 'bundler/setup'
 require 'html2rss'
-require 'byebug'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/html2rss.gemspec
+++ b/html2rss.gemspec
@@ -34,5 +34,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'vcr', '~> 4.0'
-  spec.add_development_dependency 'byebug', '~> 10.0'
 end


### PR DESCRIPTION
`nokogumbo` does not support JRuby, yet. However, it's being worked on in https://github.com/rubys/nokogumbo/issues/24.