### PR TITLE
fix(template): breaks when any method returns nil

### DIFF
--- a/lib/html2rss/attribute_post_processors/template.rb
+++ b/lib/html2rss/attribute_post_processors/template.rb
@@ -52,7 +52,7 @@ module Html2rss
 
       def methods
         @methods ||= @options['methods'].map do |method|
-          method == 'self' ? @value : @item.public_send(method.to_sym)
+          method == 'self' ? @value.to_s : @item.public_send(method.to_sym).to_s
         end
       end
     end

--- a/spec/html2rss/attribute_post_processors/template_spec.rb
+++ b/spec/html2rss/attribute_post_processors/template_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Html2rss::AttributePostProcessors::Template do
   subject { described_class.new('Hi', options: options, item: item).get }
 
-  let(:options) { { 'string' => '%s! %s is %s!', 'methods' => %w[self name autor] } }
+  let(:options) { { 'string' => '%s! %s is %s! %s', 'methods' => %w[self name autor returns_nil] } }
 
   # An instance_double does not work with method_missing.
   # rubocop:disable RSpec/VerifiedDoubles
@@ -11,7 +11,8 @@ RSpec.describe Html2rss::AttributePostProcessors::Template do
   before do
     allow(item).to receive(:name).and_return('My name')
     allow(item).to receive(:autor).and_return('Slim Shady')
+    allow(item).to receive(:returns_nil).and_return(nil)
   end
 
-  it { is_expected.to eq 'Hi! My name is Slim Shady!' }
+  it { is_expected.to eq 'Hi! My name is Slim Shady! ' }
 end


### PR DESCRIPTION
solution: always make it a string first