### PR TITLE
feat(post_processors): add markdown to html

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ PATH
       faraday (~> 0.15)
       faraday_middleware (~> 0.13)
       hashie (~> 3.6)
+      kramdown
       mime-types (> 3.0)
       nokogiri (>= 1.10, < 2.0)
       reverse_markdown (~> 1.3)
@@ -38,6 +39,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.3)
     json (2.2.0)
+    kramdown (2.1.0)
     mime-types (3.3)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.1009)

--- a/html2rss.gemspec
+++ b/html2rss.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday', '~> 0.15'
   spec.add_dependency 'faraday_middleware', '~> 0.13'
   spec.add_dependency 'hashie', '~> 3.6'
+  spec.add_dependency 'kramdown'
   spec.add_dependency 'mime-types', '> 3.0'
   spec.add_dependency 'nokogiri', '>= 1.10', '< 2.0'
   spec.add_dependency 'reverse_markdown', '~> 1.3'

--- a/lib/html2rss/attribute_post_processors/markdown_to_html.rb
+++ b/lib/html2rss/attribute_post_processors/markdown_to_html.rb
@@ -1,0 +1,48 @@
+require 'kramdown'
+
+module Html2rss
+  module AttributePostProcessors
+    ##
+    # Generates HTML from Markdown.
+    #
+    # It's particularly useful in conjunction with the Template post processor
+    # to generate a description from other selectors.
+    #
+    # YAML usage example:
+    #
+    #    selectors:
+    #      description:
+    #        selector: section
+    #        post_process:
+    #          - name: template
+    #            string: |
+    #              # %s
+    #
+    #              Price: %s
+    #            methods:
+    #              - self
+    #              - price
+    #          - name: html_to_markdown
+    #
+    # Would e.g. return:
+    #
+    #    <h1>Section</h1>
+    #
+    #    <p>Price: 12.34</p>
+    class MarkdownToHtml
+      def initialize(value, env)
+        @value = value
+        @env = env
+      end
+
+      ##
+      # @return [String] formatted in Markdown
+      def get
+        SanitizeHtml.new(
+          Kramdown::Document.new(@value).to_html,
+          @env
+        ).get
+      end
+    end
+  end
+end

--- a/spec/config.json.test.yml
+++ b/spec/config.json.test.yml
@@ -42,3 +42,14 @@ feeds:
         - mpaa_rating
         - grade
         - year
+      description:
+        post_process:
+          - name: template
+            string: |
+              # %s
+
+              MPAA rating: %s
+            methods:
+              - movie_title
+              - mpaa_rating
+          - name: markdown_to_html

--- a/spec/html2rss/attribute_post_processors/markdown_to_html_spec.rb
+++ b/spec/html2rss/attribute_post_processors/markdown_to_html_spec.rb
@@ -1,0 +1,40 @@
+RSpec.describe Html2rss::AttributePostProcessors::MarkdownToHtml do
+  subject { described_class.new(markdown, config: config).get }
+
+  let(:config) {
+    Html2rss::Config.new(
+      channel: { title: 'Example: questions', url: 'https://example.com/questions' }
+    )
+  }
+
+  let(:markdown) {
+    <<~MD
+      # Section
+
+      Price: 12.34
+
+      - Item 1
+      - Item 2
+
+      `puts 'hello world'`
+    MD
+  }
+
+  let(:html) {
+    <<~HTML
+      <h1>Section</h1>
+
+      <p>Price: 12.34</p>
+
+      <ul>
+        <li>Item 1</li>
+        <li>Item 2</li>
+      </ul>
+
+      <p><code>puts 'hello world'</code></p>
+    HTML
+      .squish
+  }
+
+  it { is_expected.to eq html }
+end

--- a/spec/html2rss_spec.rb
+++ b/spec/html2rss_spec.rb
@@ -34,6 +34,15 @@ RSpec.describe Html2rss do
       it 'returns a RSS:Rss instance' do
         expect(feed).to be_a_kind_of(RSS::Rss)
       end
+
+      context 'with returned rss feed' do
+        subject(:xml) { Nokogiri::XML(feed.to_s) }
+
+        it 'has the description derived from markdown' do
+          expect(xml.css('item > description').first.text)
+            .to eq '<h1>GOLDFINCH, THE</h1> <p>MPAA rating: R</p>'
+        end
+      end
     end
   end
 


### PR DESCRIPTION
It's particularly useful in conjunction with the Template post processor
to generate a nicely layed out description from other selectors.