### PR TITLE
chore(travis): test current rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ before_install:
 bundler_args: "--jobs=3 --retry=3"
 
 rvm:
-  - 2.4.9
-  - 2.5.7
-  - 2.6.5
-  - 2.7.0
+  - 2.4.10
+  - 2.5.8
+  - 2.6.6
+  - 2.7.1
 
 script:
   - bundle exec rubocop -F


### PR DESCRIPTION
I keep the eol'ed ruby 2.4 in there (for now),
as this gem works fine with it.