### PR TITLE
feat: require at least ruby version 2.5

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   DisplayCopNames: true
 
 Metrics/BlockLength:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ before_install:
 bundler_args: "--jobs=3 --retry=3"
 
 rvm:
-  - 2.4.10
   - 2.5.8
   - 2.6.6
   - 2.7.1

--- a/html2rss.gemspec
+++ b/html2rss.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'Give the URL to scrape and some CSS selectors. Get a RSS::Rss instance in return.'
   spec.homepage      = 'https://github.com/gildesmarais/html2rss'
   spec.license       = 'MIT'
-  spec.required_ruby_version = '>= 2.4.4'
+  spec.required_ruby_version = '>= 2.5.0'
 
   if spec.respond_to?(:metadata)
     spec.metadata['allowed_push_host'] = 'https://rubygems.org'


### PR DESCRIPTION
Ruby 2.4 EOL'ed recently. Since some deps do not support 2.4 any longer, this gem won't support it either.